### PR TITLE
chore: Temporarily disable gapic generation for gameservices

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -22,19 +22,4 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 
 gapic = gcp.GAPICGenerator()
 common_templates = gcp.CommonTemplates()
-
-versions = ['v1alpha']
-service = 'gameservices'
-config_pattern = "/google/cloud/gaming/artman_gameservices_{version}.yaml"
-
-for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern=config_pattern,
-    package_pattern="com.google.cloud.gaming.{version}",
-    gapic=gapic,
-    private=True,
-  )
-
 java.common_templates()


### PR DESCRIPTION
There are no plans to regenerate new versions of gameservices-v1alpha, that is why it was removed from synth.py. When v1 version is available, it will be added to synth.py (using bazel generation).

